### PR TITLE
Format install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Write A Song In JavaScript
 ## Install
 npm
 
-```
-$ npm install beeplay
+```sh
+npm install beeplay
 ```
 
 bower
 
-```
-$bower install beeplay
+```sh
+bower install beeplay
 ```
 
 ## Usage


### PR DESCRIPTION
The install instructions aren't easily copy-and-pasteable and `$` are usually omitted anyways.